### PR TITLE
Fix loading of documents with relative paths

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	ketchup "thdwb/ketchup"
 	mustard "thdwb/mustard"
 	profiler "thdwb/profiler"
@@ -12,6 +14,10 @@ func loadDocument(browser *structs.WebBrowser, link string) {
 	URL := sauce.ParseURL(link)
 
 	if URL.Scheme == "" && URL.Host == "" {
+		if !strings.HasPrefix(URL.Path, "/") {
+			URL.Path = "/" + URL.Path
+		}
+
 		URL = sauce.ParseURL(browser.Document.URL.Scheme + "://" + browser.Document.URL.Host + URL.Path)
 	}
 


### PR DESCRIPTION
HTML anchors with an href that does not start with a `/`, i.e. that have
a relative path, need to be prefixed with `/` to properly join them to
the base host.

An example can be seen on https://unobtanium.de. The links are relative
to the root directory. Without this patch, the browser crashes when trying
to load them.