### PR TITLE
Make mayo's mapSizeValue function more resilient

### DIFF
--- a/mayo/mayo.go
+++ b/mayo/mayo.go
@@ -1,6 +1,7 @@
 package mayo
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,8 @@ func getDefaultElementFontWeight(element string) int {
 }
 
 func mapSizeValue(sizeValue string) float64 {
-	valueString := sizeValue[0 : len(sizeValue)-2]
+	re := regexp.MustCompile("[0-9]+")
+	valueString := re.FindString(sizeValue)
 	value, err := strconv.ParseInt(valueString, 10, 0)
 
 	if err != nil {


### PR DESCRIPTION
Previous implementation would crash the browser if the sizeValue had no
attached unit. Discovered by attempting to browse to https://github.com.

This fix makes the parser more flexible by using regex to extract the
value.

https://github.com now loads without the browser crashing.